### PR TITLE
Ordner-Pfad angepasst

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,11 @@ Vagrant.configure("2") do |config|
       # Startet die Maschine im Hintergrund
       vb.gui = false
     end
+    win_server.vm.synced_folder '.', '/vagrant', disabled: true
+    host_shared_folder = ENV["HOME"] + "/Shared" #legt einen neuen Ordner an, Pfad kann nach Bedarf angepasst werden
+    guest_shared_folder = "C:/Shared" # Pfad auf der VM
+    win_server.vm.synced_folder host_shared_folder, guest_shared_folder, create:true
+
     win_server.vm.network "private_network", ip: "192.168.56.200", name: 'VirtualBox Host-Only Ethernet Adapter'
     win_server.vm.guest = :windows
     win_server.vm.communicator = "winrm"
@@ -25,6 +30,12 @@ Vagrant.configure("2") do |config|
       vb.memory = 4000
       vb.cpus = 2
     end
+    kali.vm.synced_folder '.', '/vagrant', disabled: true
+    host_shared_folder = ENV["HOME"] + "/Shared" # legt einen neuen Ordner auf dem Host an, Pfad kann nach Bedarf angepasst werden
+    guest_shared_folder = "/home/vagrant/Shared" # Pfad auf der VM
+    kali.vm.synced_folder host_shared_folder, guest_shared_folder, create:true
+
+
     kali.vm.network "private_network", ip: "192.168.56.100", name: 'VirtualBox Host-Only Ethernet Adapter'
     kali.vm.communicator = "ssh"
     kali.vm.provision "shell", inline: <<~SHELL 


### PR DESCRIPTION
Auf dem Host wird ein Ordner "Shared" angelegt unter C:/Users/{Benutzername} auf den beide VMs Zugriff haben. Auf Kali liegt der Shared Ordner unter /home/vagrant und auf WIndows unter C:/. Außerdem wurden die default shared Ordner von vagrant deaktiviert.